### PR TITLE
[FIX] Toast display when dialog is open

### DIFF
--- a/src/api/queries/users-queries.ts
+++ b/src/api/queries/users-queries.ts
@@ -15,6 +15,7 @@ import { useContext } from "react";
 import { UserContext } from "@/contexts/user-context";
 import { FolderContentRequest, NodeTypes } from "@/types/node-types";
 import showToast from "@/lib/show-toast";
+import { AxiosError } from "axios";
 
 const BASE_KEY = "users";
 const NODE_KEY = "nodes";
@@ -59,6 +60,11 @@ export const useCreateFolder = (userId: number, callback?: () => void) => {
       }
       showToast("Folder successfully created");
     },
+    onError: () => {
+      if (callback) {
+        callback();
+      }
+    },
   });
 
   return { createNewFolder, isLoading };
@@ -77,6 +83,16 @@ export const useCreateFile = (userId: number, callback?: () => void) => {
       }
       showToast("File  successfully created");
     },
+    onError: (err) => {
+      if (callback) {
+        callback();
+      }
+      if (err instanceof AxiosError) {
+        const errorMessage = err?.response?.data.error;
+        return showToast(errorMessage, "error");
+      }
+      return showToast(err.message, "error");
+    },
   });
 
   return {
@@ -93,11 +109,22 @@ export const useUpdateNode = (userId: number, callback?: () => void) => {
       queryClient.invalidateQueries({
         queryKey: [NODE_KEY, userId],
       });
+
+      const isFile = data.type === NodeTypes.FILE;
+      showToast(`${isFile ? "File" : "Folder"} successfully updated`);
       if (callback) {
         callback();
       }
-      const isFile = data.type === NodeTypes.FILE;
-      showToast(`${isFile ? "File" : "Folder"} successfully updated`);
+    },
+    onError: (err) => {
+      if (callback) {
+        callback();
+      }
+      if (err instanceof AxiosError) {
+        const errorMessage = err?.response?.data.error;
+        return showToast(errorMessage, "error");
+      }
+      return showToast(err.message, "error");
     },
   });
 

--- a/src/components/create-node-modal.tsx
+++ b/src/components/create-node-modal.tsx
@@ -63,7 +63,7 @@ const CreateNodeModal = forwardRef<HTMLDialogElement, CreateNodeModalProps>(
                 editedNode={editedNode}
                 folderOptions={folderOptions}
                 defaultFolderOption={defaultFolderOption}
-                onSuccessfulMutation={closeModal}
+                onMutation={closeModal}
               />
             )
           : !isLoading && (
@@ -71,7 +71,7 @@ const CreateNodeModal = forwardRef<HTMLDialogElement, CreateNodeModalProps>(
                 editedNode={editedNode}
                 folderOptions={folderOptions}
                 defaultFolderOption={defaultFolderOption}
-                onSuccessfulMutation={closeModal}
+                onMutation={closeModal}
               />
             )}
       </Modal>

--- a/src/components/file-form.tsx
+++ b/src/components/file-form.tsx
@@ -34,14 +34,14 @@ type FileFormProps = {
   folderOptions: FolderOption[];
   defaultFolderOption: FolderOption | null;
   editedNode?: EditNodeCell | null;
-  onSuccessfulMutation?: () => void;
+  onMutation?: () => void;
 };
 
 export default function FileForm({
   folderOptions,
   defaultFolderOption,
   editedNode,
-  onSuccessfulMutation,
+  onMutation,
 }: FileFormProps) {
   const {
     register,
@@ -60,15 +60,8 @@ export default function FileForm({
   });
   const { user } = useContext(UserContext);
   const userId = user!.userId;
-  const { createNewFile, isLoading } = useCreateFile(
-    userId,
-    onSuccessfulMutation
-  );
-  const { updateNodeData } = useUpdateNode(
-    userId,
-
-    onSuccessfulMutation
-  );
+  const { createNewFile, isLoading } = useCreateFile(userId, onMutation);
+  const { updateNodeData } = useUpdateNode(userId, onMutation);
 
   const onSubmit = (data: FileFormFields, e?: BaseSyntheticEvent) => {
     e?.preventDefault();

--- a/src/components/folder-form.tsx
+++ b/src/components/folder-form.tsx
@@ -30,14 +30,14 @@ type FolderFormProps = {
   folderOptions: FolderOption[];
   defaultFolderOption: FolderOption | null;
   editedNode?: EditNodeCell | null;
-  onSuccessfulMutation?: () => void;
+  onMutation?: () => void;
 };
 
 export default function FolderForm({
   folderOptions,
   defaultFolderOption,
   editedNode,
-  onSuccessfulMutation,
+  onMutation,
 }: FolderFormProps) {
   const {
     register,
@@ -56,11 +56,8 @@ export default function FolderForm({
   });
   const { user } = useContext(UserContext);
   const userId = user!.userId;
-  const { createNewFolder, isLoading } = useCreateFolder(
-    userId,
-    onSuccessfulMutation
-  );
-  const { updateNodeData } = useUpdateNode(userId, onSuccessfulMutation);
+  const { createNewFolder, isLoading } = useCreateFolder(userId, onMutation);
+  const { updateNodeData } = useUpdateNode(userId, onMutation);
 
   const isEditMode = !!editedNode;
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,7 +7,7 @@ import { ToastContainer } from "react-toastify";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <ToastContainer />
+    <ToastContainer position="top-center" />
     <QueryClientProvider client={queryClient}>
       <App />
     </QueryClientProvider>


### PR DESCRIPTION
Due to the usage of HTML dialog element and its content rendered in the top layer, the toast displayed on mutations is hidden behind backdrop.
Temporary fix - dialog closes on both successful and failed mutations

 